### PR TITLE
Fix invisible selection color in code blocks (Firefox)

### DIFF
--- a/website/static/css/prism-ghcolors.css
+++ b/website/static/css/prism-ghcolors.css
@@ -25,20 +25,6 @@ pre[class*='language-'] {
   hyphens: none;
 }
 
-pre[class*='language-']::-moz-selection,
-pre[class*='language-'] ::-moz-selection,
-code[class*='language-']::-moz-selection,
-code[class*='language-'] ::-moz-selection {
-  background: #fff;
-}
-
-/* pre[class*='language-']::selection,
-pre[class*='language-'] ::selection,
-code[class*='language-']::selection,
-code[class*='language-'] ::selection {
-  background: #b3d4fc;
-} */
-
 /* Code blocks */
 pre[class*='language-'] {
   padding: 1em;


### PR DESCRIPTION
Code blocks have a white background-color. In Firefox, selected code was invisible due to `::-moz-selection` styles also declaring a white background (probably a result of older code?).

This PR also removes the commented out `::selection` colors.
